### PR TITLE
Update agent's Docker tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Use this module in your Terraform configuration:
 ```hcl
 module "airplane_agent" {
   source  = "airplanedev/airplane-cluster/aws"
-  version = "0.4.0"
+  version = "0.4.1"
 
   api_token              = "YOUR_API_TOKEN"
   team_id                = "YOUR_TEAM_ID"

--- a/packer/conf/airplane-agent.service
+++ b/packer/conf/airplane-agent.service
@@ -10,7 +10,7 @@ Type=simple
 User=airplane-agent
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
-ExecStartPre=/usr/bin/docker pull airplanedev/agent:1
+ExecStartPre=/usr/bin/docker pull airplanedev/agent:v1
 ExecStart=/usr/bin/docker run --rm \
     --env-file /etc/airplane-agent/airplane-agent.env \
     -v /var/run/docker.sock:/var/run/docker.sock \


### PR DESCRIPTION
We just publish to v1 now: https://hub.docker.com/r/airplanedev/agent/tags?page=1&ordering=last_updated