### PR TITLE
Revert "Update agent's Docker tag"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Use this module in your Terraform configuration:
 ```hcl
 module "airplane_agent" {
   source  = "airplanedev/airplane-cluster/aws"
-  version = "0.4.1"
+  version = "0.4.0"
 
   api_token              = "YOUR_API_TOKEN"
   team_id                = "YOUR_TEAM_ID"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Use this module in your Terraform configuration:
 ```hcl
 module "airplane_agent" {
   source  = "airplanedev/airplane-cluster/aws"
-  version = "0.4.0"
+  version = "0.4.2"
 
   api_token              = "YOUR_API_TOKEN"
   team_id                = "YOUR_TEAM_ID"

--- a/packer/conf/airplane-agent.service
+++ b/packer/conf/airplane-agent.service
@@ -10,7 +10,7 @@ Type=simple
 User=airplane-agent
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
-ExecStartPre=/usr/bin/docker pull airplanedev/agent:v1
+ExecStartPre=/usr/bin/docker pull airplanedev/agent:1
 ExecStart=/usr/bin/docker run --rm \
     --env-file /etc/airplane-agent/airplane-agent.env \
     -v /var/run/docker.sock:/var/run/docker.sock \


### PR DESCRIPTION
Reverts airplanedev/terraform-aws-airplane-cluster#1

This will revert agent behavior back to consuming the `:1` tag instead of `:v1`. I'll release as `v0.4.2` once merged.