### PR TITLE
Adjust security groups, instance_refresh behavior, and variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ module "airplane_agent" {
   vpc_subnet_ids         = ["subnet-000", "subnet-111"]
   # Any additional security groups (optional)
   vpc_security_group_ids = ["sg-222"]
+  # Change number of instances / agents
+  instance_count = 3
+  # Change instance type (default t3.medium)
+  instance_type = "t3.large"
 }
 
 resource "aws_iam_policy" "agent" {

--- a/variables.tf
+++ b/variables.tf
@@ -24,9 +24,9 @@ variable "agent_ami" {
   }
 }
 
-variable "aws_region" {
-  type    = string
-  default = "us-west-2"
+variable "instance_count" {
+  type    = number
+  default = 1
 }
 
 variable "instance_type" {
@@ -47,7 +47,8 @@ variable "tags" {
 
 variable "vpc_security_group_ids" {
   type        = list(string)
-  description = "List of security group IDs to apply to instances"
+  description = "List of security group IDs to attach to instances"
+  default     = []
 }
 
 variable "vpc_subnet_ids" {


### PR DESCRIPTION
- Include a security group by default that allows egress
- Expose instance_count as a variable, default to 1
- Specify `aws_launch_template.lt.latest_version` explicitly in ASG so
  that instance_refresh is triggered correctly
